### PR TITLE
(perf) 使用免递归方式创建树形结构列表，优化响应速度

### DIFF
--- a/blossom-backend/backend/src/main/java/com/blossom/backend/server/utils/DocUtil.java
+++ b/blossom-backend/backend/src/main/java/com/blossom/backend/server/utils/DocUtil.java
@@ -1,6 +1,7 @@
 package com.blossom.backend.server.utils;
 
 import cn.hutool.core.collection.CollUtil;
+import cn.hutool.core.collection.CollectionUtil;
 import cn.hutool.core.util.StrUtil;
 import com.blossom.backend.server.article.draft.pojo.ArticleEntity;
 import com.blossom.backend.server.doc.DocTypeEnum;
@@ -11,7 +12,9 @@ import com.blossom.common.base.util.SortUtil;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -34,23 +37,32 @@ public class DocUtil {
      * @return 树状菜单对象
      */
     public static List<DocTreeRes> treeWrap(List<DocTreeRes> list, boolean priorityType) {
-        final List<DocTreeRes> allList = list;
-        //查询根菜单
-        List<DocTreeRes> rootLevel =
-                allList.stream()
-                        .filter(p -> p.getP().equals(ROOT_FOLDER_ID))
-                        .sorted(Comparator.comparing(DocTreeRes::getS))
-                        .sorted((d1, d2) -> {
-                            if (priorityType) {
-                                if (d2.getTy().equals(d1.getTy())) {
-                                    return d1.getS() - d2.getS();
-                                }
-                                return d2.getTy() - d1.getTy();
-                            }
-                            return SortUtil.intSort.compare(d1.getS(), d2.getS());
-                        })
-                        .collect(Collectors.toList());
-        rootLevel.parallelStream().forEach(item -> setChild(item, allList));
+        // 将原始列表进行分组， 并排序每个分组的列表
+        Map<Long, List<DocTreeRes>> pidMapping = list.stream().collect(
+                Collectors.groupingBy(DocTreeRes::getP, HashMap::new,
+                Collectors.collectingAndThen(Collectors.toList(),
+                item -> item.stream().sorted(Comparator.comparingInt(DocTreeRes::getS)).collect(Collectors.toList()))));
+        // 免递归方式赋值子菜单
+        list.parallelStream().forEach(item -> {
+            if (!CollectionUtil.isEmpty(pidMapping.get(item.getI()))){
+                item.setChildren(pidMapping.get(item.getI()));
+            }
+        });
+        // 查询根菜单
+        List<DocTreeRes> rootLevel = list.stream()
+                .filter(p -> p.getP().equals(ROOT_FOLDER_ID))
+                .sorted(Comparator.comparing(DocTreeRes::getS))
+                .sorted((d1, d2) -> {
+                    if (priorityType) {
+                        if (d2.getTy().equals(d1.getTy())) {
+                            return d1.getS() - d2.getS();
+                        }
+                        return d2.getTy() - d1.getTy();
+                    }
+                    return SortUtil.intSort.compare(d1.getS(), d2.getS());
+                })
+                .collect(Collectors.toList());
+
         return rootLevel;
     }
 


### PR DESCRIPTION
原通过递归方式进行树形结构列表的构造，在数据量增加后，响应时间会明显增加
以下为6000+文章场景下的测试结果
before:
![8b8a73a8-6720-4f2b-8f92-347e88f9a56c](https://github.com/blossom-editor/blossom/assets/47469230/89e4c634-d551-414d-82d0-0856dd857bb0)

after:
![img_v3_0269_01a399fe-4afa-43fd-8964-fc875dc3f66g](https://github.com/blossom-editor/blossom/assets/47469230/a63bf1c2-1af1-4602-8944-8b0c5fbea682)
