### PR TITLE
(fixed) 修改lucene版本, 支持8版本jre运行

### DIFF
--- a/blossom-backend/backend/pom.xml
+++ b/blossom-backend/backend/pom.xml
@@ -73,19 +73,19 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>9.9.1</version>
+            <version>8.11.2</version>
         </dependency>
         <!-- Lucene解析库 -->
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
-            <version>9.9.1</version>
+            <version>8.11.2</version>
         </dependency>
         <!-- Lucene结果高亮 -->
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-highlighter</artifactId>
-            <version>9.9.1</version>
+            <version>8.11.2</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
9.x lucene不支持8版本jre，替换为8.x版本lucene. 修改后，旧有索引需要手动清除