### PR TITLE
feat: article subject list by star.

### DIFF
--- a/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/FolderController.java
+++ b/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/FolderController.java
@@ -5,6 +5,8 @@ import cn.hutool.core.util.ObjUtil;
 import com.blossom.backend.base.auth.AuthContext;
 import com.blossom.backend.base.auth.annotation.AuthIgnore;
 import com.blossom.backend.config.BlConstants;
+import com.blossom.backend.server.article.draft.pojo.ArticleEntity;
+import com.blossom.backend.server.article.draft.pojo.ArticleStarReq;
 import com.blossom.backend.server.article.draft.pojo.ArticleUpdTagReq;
 import com.blossom.backend.server.doc.DocService;
 import com.blossom.backend.server.folder.pojo.*;
@@ -44,15 +46,27 @@ public class FolderController {
         if (userId == null) {
             return R.ok(new ArrayList<>());
         }
-        return R.ok(baseService.subjects(userId));
+        return R.ok(baseService.subjects(userId, null));
     }
 
     /**
      * 查询专题列表
      */
     @GetMapping("/subjects")
-    public R<List<FolderSubjectRes>> listSubject() {
-        return R.ok(baseService.subjects(AuthContext.getUserId()));
+    public R<List<FolderSubjectRes>> listSubject(@RequestParam("starStatus") Integer starStatus) {
+        return R.ok(baseService.subjects(AuthContext.getUserId(), starStatus));
+    }
+
+    /**
+     * 星标目录
+     *
+     * @param req 目录对象
+     */
+    @PostMapping("/star")
+    public R<Long> star(@Validated @RequestBody FolderStarReq req) {
+        FolderEntity folder = req.to(FolderEntity.class);
+        folder.setUserId(AuthContext.getUserId());
+        return R.ok(baseService.update(folder));
     }
 
     /**
@@ -68,6 +82,7 @@ public class FolderController {
         FolderRes res = entity.to(FolderRes.class);
         res.setTags(DocUtil.toTagList(entity.getTags()));
         res.setType(entity.getType());
+        res.setStarStatus(entity.getStarStatus());
         return R.ok(res);
     }
 

--- a/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/pojo/FolderEntity.java
+++ b/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/pojo/FolderEntity.java
@@ -45,6 +45,10 @@ public class FolderEntity extends AbstractPOJO implements Serializable {
      */
     private String tags;
     /**
+     * star状态
+     */
+    private Integer starStatus;
+    /**
      * 开放状态
      */
     private Integer openStatus;

--- a/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/pojo/FolderQueryReq.java
+++ b/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/pojo/FolderQueryReq.java
@@ -16,6 +16,10 @@ import java.io.Serializable;
 public class FolderQueryReq extends PageReq implements Serializable {
 
     private static final long serialVersionUID = 1L;
+    /**
+     * star状态
+     */
+    private Integer starStatus;
 
     private String tags;
 

--- a/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/pojo/FolderRes.java
+++ b/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/pojo/FolderRes.java
@@ -40,6 +40,10 @@ public class FolderRes extends AbstractPOJO implements Serializable {
      */
     private List<String> tags;
     /**
+     * star状态
+     */
+    private Integer starStatus;
+    /**
      * 是否公开文件夹 [0:未公开，1:公开]
      */
     private Integer openStatus;

--- a/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/pojo/FolderStarReq.java
+++ b/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/pojo/FolderStarReq.java
@@ -1,0 +1,37 @@
+package com.blossom.backend.server.folder.pojo;
+
+
+import com.blossom.common.base.enums.YesNo;
+import com.blossom.common.base.pojo.AbstractPOJO;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+/**
+ * 文章 star
+ *
+ * @author xzzz
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class FolderStarReq extends AbstractPOJO {
+
+    /**
+     * 目录ID
+     */
+    @Min(value = 0, message = "[目录ID] 不能小于0")
+    @NotNull(message = "[目录ID] 为必填项")
+    private Long id;
+
+    /**
+     * star 状态 {@link YesNo}
+     * @see YesNo
+     */
+    @Min(value = 0, message = "[star 状态] 不能小于0")
+    @Max(value = 1, message = "[star 状态] 不能大于1")
+    @NotNull(message = "[star 状态] 为必填项")
+    private Integer starStatus;
+}

--- a/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/pojo/FolderUpdReq.java
+++ b/blossom-backend/backend/src/main/java/com/blossom/backend/server/folder/pojo/FolderUpdReq.java
@@ -33,6 +33,10 @@ public class FolderUpdReq extends AbstractPOJO implements Serializable {
     private String name;
     /** 图标 */
     private String icon;
+    /**
+     * star状态
+     */
+    private Integer starStatus;
     /** 标签 */
     private List<String> tags;
     /** 排序 */

--- a/blossom-backend/backend/src/main/resources/application.yml
+++ b/blossom-backend/backend/src/main/resources/application.yml
@@ -37,6 +37,7 @@ spring:
     init:
       mode: always
       platform: mysql
+      continue-on-error: true
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫ mybatis ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/blossom-backend/backend/src/main/resources/mapper/FolderMapper.xml
+++ b/blossom-backend/backend/src/main/resources/mapper/FolderMapper.xml
@@ -9,6 +9,7 @@
             `name`,
             icon,
             tags,
+            star_status,
             open_status,
             sort,
             cover,
@@ -21,6 +22,7 @@
             cre_time
           from blossom_folder
         <where>
+            <if test="starStatus != null ">and star_status = #{starStatus}</if>
             <if test="openStatus != null ">and open_status = #{openStatus}</if>
             <if test="type != null ">and type = #{type}</if>
             <if test="tags != null and tags != ''">and tags like concat('%',#{tags},'%')</if>
@@ -62,6 +64,7 @@
             <if test="name != null">`name` = #{name},</if>
             <if test="icon != null">icon = #{icon},</if>
             <if test="tags != null">tags = #{tags},</if>
+            <if test="starStatus != null">star_status = #{starStatus},</if>
             <if test="sort != null">sort = #{sort},</if>
             <if test="cover != null">cover = #{cover},</if>
             <if test="color != null">color = #{color},</if>

--- a/blossom-backend/backend/src/main/resources/schema-mysql.sql
+++ b/blossom-backend/backend/src/main/resources/schema-mysql.sql
@@ -435,7 +435,6 @@ CREATE TABLE IF NOT EXISTS `blossom_folder`
     `name`             varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '' COMMENT '文件夹名称',
     `icon`             varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '' COMMENT '图标',
     `tags`             varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '' COMMENT '标签',
-    `star_status`      tinyint(1)                                             NOT NULL DEFAULT 0 COMMENT '收藏 0:否,1:是',
     `open_status`      tinyint(1)                                             NOT NULL DEFAULT 0 COMMENT '开放状态',
     `sort`             int UNSIGNED                                           NOT NULL DEFAULT 1 COMMENT '排序',
     `cover`            varchar(300) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '' COMMENT '封面图片',
@@ -459,6 +458,7 @@ alter table blossom_folder
     modify icon varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL default '' comment '图标';
 alter table blossom_folder
     modify sort int NOT NULL default 1 comment '排序';
+alter table blossom_folder add column star_status tinyint(1) NOT NULL DEFAULT 0 COMMENT '收藏 0:否,1:是';
 
 -- ----------------------------
 -- Records of blossom_folder

--- a/blossom-backend/backend/src/main/resources/schema-mysql.sql
+++ b/blossom-backend/backend/src/main/resources/schema-mysql.sql
@@ -458,7 +458,6 @@ alter table blossom_folder
     modify icon varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL default '' comment '图标';
 alter table blossom_folder
     modify sort int NOT NULL default 1 comment '排序';
-alter table blossom_folder add column star_status tinyint(1) NOT NULL DEFAULT 0 COMMENT '收藏 0:否,1:是';
 
 -- ----------------------------
 -- Records of blossom_folder
@@ -640,3 +639,6 @@ CREATE TABLE IF NOT EXISTS `base_user_param`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT = '用户参数'
   COLLATE = utf8mb4_bin;
+
+-- Code that might be wrong goes last
+alter table blossom_folder add column star_status tinyint(1) NOT NULL DEFAULT 0 COMMENT '收藏 0:否,1:是';

--- a/blossom-backend/backend/src/main/resources/schema-mysql.sql
+++ b/blossom-backend/backend/src/main/resources/schema-mysql.sql
@@ -435,6 +435,7 @@ CREATE TABLE IF NOT EXISTS `blossom_folder`
     `name`             varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '' COMMENT '文件夹名称',
     `icon`             varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '' COMMENT '图标',
     `tags`             varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '' COMMENT '标签',
+    `star_status`      tinyint(1)                                             NOT NULL DEFAULT 0 COMMENT '收藏 0:否,1:是',
     `open_status`      tinyint(1)                                             NOT NULL DEFAULT 0 COMMENT '开放状态',
     `sort`             int UNSIGNED                                           NOT NULL DEFAULT 1 COMMENT '排序',
     `cover`            varchar(300) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '' COMMENT '封面图片',

--- a/blossom-editor/src/renderer/src/api/blossom.ts
+++ b/blossom-editor/src/renderer/src/api/blossom.ts
@@ -275,6 +275,15 @@ export const articleStarApi = (data?: object): Promise<R<any>> => {
 }
 
 /**
+ * star 或取消 star
+ * @param data
+ * @returns
+ */
+export const folderStarApi = (data?: object): Promise<R<any>> => {
+  return rq.post<R<any>>('/folder/star', data)
+}
+
+/**
  * 下载文章 markdown
  * @param params
  * @returns

--- a/blossom-editor/src/renderer/src/views/article/ArticleInfo.vue
+++ b/blossom-editor/src/renderer/src/views/article/ArticleInfo.vue
@@ -69,7 +69,7 @@
 
         <!-- 星标 -->
         <div class="stat-star">
-          <div v-if="!curIsStar" :class="['iconbl bl-star-line', curDocDialogType == 'add' || curIsFolder ? 'disabled' : '']" @click="star(1)"></div>
+          <div v-if="!curIsStar" :class="['iconbl bl-star-line', curDocDialogType == 'add']" @click="star(1)"></div>
           <div v-else class="iconbl bl-star-fill" @click="star(0)"></div>
         </div>
       </div>
@@ -239,6 +239,7 @@ import {
 import { isNotBlank, isNull } from '@renderer/assets/utils/obj'
 import { openExtenal, openNewIconWindow } from '@renderer/assets/utils/electron'
 import Notify from '@renderer/scripts/notify'
+import {folderStarApi} from "../../api/blossom";
 
 //#region --------------------------------------------------< 基本信息 >--------------------------------------------------
 const userStore = useUserStore()
@@ -481,6 +482,12 @@ const star = (changeStarStatus: number) => {
   if (curIsArticle.value) {
     docForm.value.starStatus = changeStarStatus
     articleStarApi({ id: docForm.value.id, starStatus: docForm.value.starStatus }).then(() => {
+      Notify.success(docForm.value.starStatus === 0 ? '取消 Star 成功' : 'Star 成功')
+    })
+  }
+  if (curIsFolder.value) {
+    docForm.value.starStatus = changeStarStatus
+    folderStarApi({ id: docForm.value.id, starStatus: docForm.value.starStatus }).then(() => {
       Notify.success(docForm.value.starStatus === 0 ? '取消 Star 成功' : 'Star 成功')
     })
   }

--- a/blossom-editor/src/renderer/src/views/home/ArticleSubjects.vue
+++ b/blossom-editor/src/renderer/src/views/home/ArticleSubjects.vue
@@ -56,7 +56,7 @@ let maxWords = 0
 const subjects = ref<any>([])
 
 const getSubjects = () => {
-  subjectsApi().then((resp) => {
+  subjectsApi({ starStatus: 1 }).then((resp) => {
     subjects.value = resp.data
     if (!isEmpty(resp.data)) {
       maxWords = resp.data

--- a/blossom-web/src/views/index/HomeSubject.vue
+++ b/blossom-web/src/views/index/HomeSubject.vue
@@ -26,7 +26,7 @@ import { subjectsApi } from '@/api/blossom'
 
 onMounted(() => {
   subjects.value = []
-  subjectsApi().then((resp) => {
+  subjectsApi({ starStatus: 1 }).then((resp) => {
     subjects.value = resp.data
   })
 })


### PR DESCRIPTION
实现了，编辑器首页，收藏专题的正常展示。

给`folder`添加了个字段 `star_status`。
添加了对应的API接口，并调整了编辑器端的接口调用。
web博客端没动。

首先需要配置目录为 专题，并且点上收藏
![image](https://github.com/blossom-editor/blossom/assets/46225881/921c177d-f66f-48a1-a279-ff87cf60cef0)

然后编辑器首页这块就会展示
![image](https://github.com/blossom-editor/blossom/assets/46225881/5a22fba7-f112-467a-bae8-4a9a3a7c6b52)
